### PR TITLE
Update items_controller.rb

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,6 +12,7 @@ class ItemsController < ApplicationController
   end
 
   def create
+    binding.pry
     @item = Item.new(items_params)
     @item.brand.destroy if @item.brand.name == ""
     if @item.save
@@ -35,11 +36,9 @@ class ItemsController < ApplicationController
 
     end
   end
-  
+
   def edit
-    if @item.brand == nil
-      @item.build_brand
-    end
+    @item.build_brand if @item.brand.nil?
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,7 +35,12 @@ class ItemsController < ApplicationController
 
     end
   end
-  def edit; end
+  
+  def edit
+    if @item.brand == nil
+      @item.build_brand
+    end
+  end
 
   def update
     if @item.update(items_params)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,6 @@ class ItemsController < ApplicationController
   end
 
   def create
-    binding.pry
     @item = Item.new(items_params)
     @item.brand.destroy if @item.brand.name == ""
     if @item.save


### PR DESCRIPTION
ブランドが登録されていない商品の編集画面を表示しようとするとエラーが発生する問題を修正
※ブランドを空で登録しようとするとエラーが生じる問題があるため、引き続き用修正。ひとまず画面表示でエラーがでなくした状況

[![Screenshot from Gyazo](https://gyazo.com/d176373a15fc05216f86cae1289ec92c/raw)](https://gyazo.com/d176373a15fc05216f86cae1289ec92c)