### PR TITLE
商品画像削除のバグ修正

### DIFF
--- a/app/views/items/_edit_form.html.haml
+++ b/app/views/items/_edit_form.html.haml
@@ -7,23 +7,22 @@
         最大10枚までアップロードできます
       .form-image
         #drop-area
-          %label
-            .image-description 
-            = f.fields_for :images do |f|
-              .file-field-group{data: {index: f.index}}
-                %label.default-label
-                  %span
-                    #{@item.images[f.index].src.identifier}
-                  = f.file_field :src, class: 'image-input image-default'
-                %span.remove-image
-                  削除
-              - if @item.persisted?
-                = f.check_box :_destroy, data:{ index: f.index }, class: 'hidden-destroy'
+          .image-description 
+          = f.fields_for :images do |f|
+            .file-field-group{data: {index: f.index}}
+              %label.default-label
+                %span
+                  #{@item.images[f.index].src.identifier}
+                = f.file_field :src, class: 'image-input image-default'
+              %span.remove-image
+                削除
             - if @item.persisted?
-              .file-field-group{data: {index: @item.images.count}}
-                = file_field_tag  :src, name: "item[images_attributes][#{@item.images.count}][src]", class: 'image-input'
-                %span.remove-image.empty-remove.remove-first
-                  削除                
+              = f.check_box :_destroy, data:{ index: f.index }, class: 'hidden-destroy'
+          - if @item.persisted?
+            .file-field-group{data: {index: @item.images.count}}
+              = file_field_tag  :src, name: "item[images_attributes][#{@item.images.count}][src]", class: 'image-input'
+              %span.remove-image.empty-remove.remove-first
+                削除                
         #previews
           - if @item.persisted?
             - @item.images.each_with_index do |image, i|


### PR DESCRIPTION
不要なラベルの削除
削除ボタンの上位に不要なラベルがあったため、削除ボタン押下時にチェックボックスにチェックを入れる処理が二重に発生してしまっていたことが原因