### PR TITLE
Ajaxエラー解消

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -1,5 +1,13 @@
 $(document).on('turbolinks:load', ()=> { 
+  fixURL();
   layoutImg();
+
+  function fixURL(){
+  var currentUrl = location.href
+  if(currentUrl=='http://localhost:3000/items' || currentUrl=='http://54.199.158.8/items'){
+  history.pushState('', '', location.href + '/new')
+  }};
+
 
   // ファイルフィールドと画像プレビューのレイアウトを整える関数
   function layoutImg(){


### PR DESCRIPTION
バリデーションエラー後のnew画面でajax通信に失敗しアラートが出る問題を解決。
理由は不明だが、遷移後のURLをitems/からitems/newに変更することで解消した。

[![Screenshot from Gyazo](https://gyazo.com/6f949323dfe9b9f80435ea2c0ca9466b/raw)](https://gyazo.com/6f949323dfe9b9f80435ea2c0ca9466b)