### PR TITLE
Payjp.jsの修正

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,8 +1,10 @@
 //DOM読み込みが完了したら実行
-document.addEventListener('DOMContentLoaded', (e) => {
-  // payjp.jsの初期化
+document.addEventListener(
+  "turbolinks:load", (e)  => {
+
+  // Payjpnの初期化
   Payjp.setPublicKey('pk_test_5368ce76b1e8ded509d2a439');
-  
+
   // ボタンのイベントハンドリング
   let btn = document.getElementById('token_submit');
   btn.addEventListener('click', (e) => {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,10 +1,9 @@
 !!!
 %html
   %head
-    %script{src: "https://js.pay.jp/", type: "text/javascript"}
-    %script{type:"text/javascript"}Payjp.setPublicKey('pk_test_5368ce76b1e8ded509d2a439');
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title FreemarketSample64c
+    %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'


### PR DESCRIPTION
# What

- Payjpがリロードされなくても動かせる様に実装
- %script{src: "https://js.pay.jp/", type: "text/javascript"}の実装箇所を適切な箇所に移動

# Why
バグ修正のため
