### PR TITLE
不具合修正

### DIFF
--- a/app/assets/stylesheets/_edit.scss
+++ b/app/assets/stylesheets/_edit.scss
@@ -31,30 +31,11 @@
 	  max-width: 343px;
 	  margin: 0 auto;
   
-	  .field-1 {
-	  	margin: 0;
-	  	text-align: left;
-	    }
-  
-	  .field {
+	  .field-edit-user {
 	  	margin: 30px 0 0;
 	  	text-align: left;
 	  }
 	  
-	  .field__password {
-		margin: 30px 0 0;
-		text-align: left;
-	  }
-	  .field-name {
-	  	margin: 30px 0 0;
-	  	text-align: left;
-	  }
-
-	  .field-detail {
-		  margin: 30px 0 0;
-		  text-align: left;
-	  }
-  
       .text-space {
 	  	padding: 10px 16px 8px;
 	  	margin: 8px 0 0;

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -6,63 +6,63 @@
       登録情報編集
     = form_for(resource, as: resource_name, url: registration_path(resource_name), builder: WithErrorFormBuilder, html: { method: :put }) do |f|
       .main-field
-        .field-1
+        .field-edit-user
           = f.label :メールアドレス
           %br/
           = f.email_field :email, autofocus: true, autocomplete: "email", class: "text-space"
         - if devise_mapping.confirmable? && resource.pending_reconfirmation?
           %div
             Currently waiting confirmation for: #{resource.unconfirmed_email}
-        .field
+        .field-edit-user
           = f.label :password
           %br/
           = f.password_field :password, autocomplete: "new-password",placeholder: "変更したい方のみ記入してください", class: "text-space"
-        .field__password
+        .field-edit-user
           = f.label :password_confirmation
           %br/
           = f.password_field :password_confirmation, autocomplete: "new-password",placeholder: "変更したい方のみ記入してください", class: "text-space"
-        .field-name
+        .field-edit-user
           = f.label :お名前（全角）
           %br/
           = f.text_field :familyname, autofocus: true, autocomplete: "familyname", class: "text-space"
           %br/
           = f.text_field :firstname, autofocus: true, autocomplete: "firstname", class: "text-space"
-        .field-name
+        .field-edit-user
           = f.label :お名前かな（全角）
           %br/
           = f.text_field :familyname_kana, autofocus: true, autocomplete: "familyname_kana", class: "text-space"
           %br/
           = f.text_field :firstname_kana, autofocus: true, autocomplete: "firstname_kana", class: "text-space"
-        .field
+        .field-edit-user
           = f.label :電話番号
           %br/
           = f.telephone_field :phonenumber, autofocus: true, autocomplete: "phonenumber", class: "text-space"
-        .field
+        .field-edit-user
           = f.label :生年月日
           %br/
           = raw sprintf(f.date_select(:birth_date, use_month_numbers: true, start_year: (Time.now.year - 100), end_year: (Time.now.year), default: Time.now(),:class =>"bootstrap-date-only-width" ,date_separator: '%s'), '年 ', '月 ') + '日'
-        .field-detail
+        .field-edit-user
           = f.label :説明
           %br/
           = f.text_area :detail, autofocus: true, autocomplete: "detail", class: "text-space"
         = f.fields_for :address do |f|
-          .field
+          .field-edit-user
             = f.label :郵便番号
             %br/
             = f.text_field :postal_code, class: "text-space"
-          .field
+          .field-edit-user
             = f.label :都道府県
             %br/
             = f.collection_select :prefecture_code, Prefecture.all, :id, :name, prompt: "--"
-          .field
+          .field-edit-user
             = f.label :市区町村
             %br/
             = f.text_field :city, class: "text-space"
-          .field
+          .field-edit-user
             = f.label :番地
             %br/
             = f.text_field :block, class: "text-space"
-          .field
+          .field-edit-user
             = f.label :建物
             %br/
             = f.text_field :building, class: "text-space"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -50,7 +50,7 @@
           %br/
           = f.date_select(:birth_date, use_month_numbers: true, prompt: "--", start_year: (Time.now.year - 100), end_year: (Time.now.year), default: Time.now(),:class =>"bootstrap-date-only-width")
         .field-user
-          = f.label :detail
+          = f.label :説明
           %span.form-require 任意
           %br/
           = f.text_area :detail, autofocus: true, autocomplete: "detail", placeholder: "自己紹介", class: "text-space"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -49,7 +49,8 @@
       ¥
       = @item.price.to_s(:delimited, delimiter: ',')
     %span.tax (税込)
-    %span.option 送料込み
+    %span.option
+      = @item.charge.name
   -if user_signed_in? && current_user.id == @item.seller_id
     = link_to edit_item_path(@item.id), class: "purchase_btn" do
       編集する
@@ -75,38 +76,40 @@
     .btn-box__delete-btn
       = link_to item_path(@item.id), method: :delete do
         %p この商品を削除する
-.item-boxes 
-  %section.item-boxes__item-box.clearfix
-    %h2.item-boxes__item-box__head
-      = link_to "" do
-        #{@item.seller.nickname}さんのその他の出品
-    .item-boxes__item-box__contents.clearfix
-      - @user_items.each do |item|
-        %section.item-boxes__item-box__contents__content
-          = link_to item_path(item.id) do
-            %figure
-              = image_tag item.images[0].src
-            .text
-              %h3
-                #{item.name}
-              .text__under
-                .text__under__price
-                  #{item.price.to_s(:delimited, delimiter: ',')}円
-.item-boxes 
-  %section.item-boxes__item-box.clearfix
-    %h2.item-boxes__item-box__head
-      = link_to "" do
-        #{@item.category.name} その他の出品
-    .item-boxes__item-box__contents.clearfix
-      - @category_items.each do |item|
-        %section.item-boxes__item-box__contents__content
-          = link_to item_path(item.id) do
-            %figure
-              = image_tag item.images[0].src
-            .text
-              %h3
-                #{item.name}
-              .text__under
-                .text__under__price
-                  #{item.price.to_s(:delimited, delimiter: ',')}円
+.item-boxes
+  - if @user_items.present?
+    %section.item-boxes__item-box.clearfix
+      %h2.item-boxes__item-box__head
+        = link_to "" do
+          #{@item.seller.nickname}さんのその他の出品
+      .item-boxes__item-box__contents.clearfix
+        - @user_items.each do |item|
+          %section.item-boxes__item-box__contents__content
+            = link_to item_path(item.id) do
+              %figure
+                = image_tag item.images[0].src
+              .text
+                %h3
+                  #{item.name}
+                .text__under
+                  .text__under__price
+                    #{item.price.to_s(:delimited, delimiter: ',')}円
+.item-boxes
+  - if @category_items.present?
+    %section.item-boxes__item-box.clearfix
+      %h2.item-boxes__item-box__head
+        = link_to "" do
+          #{@item.category.name} その他の出品
+      .item-boxes__item-box__contents.clearfix
+        - @category_items.each do |item|
+          %section.item-boxes__item-box__contents__content
+            = link_to item_path(item.id) do
+              %figure
+                = image_tag item.images[0].src
+              .text
+                %h3
+                  #{item.name}
+                .text__under
+                  .text__under__price
+                    #{item.price.to_s(:delimited, delimiter: ',')}円
 = render 'shared/footer'


### PR DESCRIPTION
- ユーザー情報編集のエラーメッセージが下の項目と被る件を解消
新規登録ビューに影響がないことは確認済み
[![Screenshot from Gyazo](https://gyazo.com/cc00b6e3937e8b2179786dbeae4caab8/raw)](https://gyazo.com/cc00b6e3937e8b2179786dbeae4caab8)

- ユーザー新規登録の「説明」項目だけ英語になっている件解消
[![Screenshot from Gyazo](https://gyazo.com/02387d0a741f0dcc9a050dbc85e6cb99/raw)](https://gyazo.com/02387d0a741f0dcc9a050dbc85e6cb99)

- 商品詳細画面で、着払いを指定しているのに送料込みになっている件修正
charge_idの値に応じて変化するよう修正
[![Screenshot from Gyazo](https://gyazo.com/37c4f5919737f061a550df2979a69977/raw)](https://gyazo.com/37c4f5919737f061a550df2979a69977)

- 商品詳細画面で、同カテゴリーの商品がない場合の表示が不適切な件修正
同カテゴリーの商品が存在する場合
[![Screenshot from Gyazo](https://gyazo.com/d94a59c46f85c65fcc03ed47005abef3/raw)](https://gyazo.com/d94a59c46f85c65fcc03ed47005abef3)
同カテゴリーの商品が存在しない場合
[![Screenshot from Gyazo](https://gyazo.com/8a236b31d3c79868f0c43aa71eadaabd/raw)](https://gyazo.com/8a236b31d3c79868f0c43aa71eadaabd)