### PR TITLE
バグフィックスと機能向上

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,6 +1,8 @@
 //DOM読み込みが完了したら実行
 document.addEventListener(
   "turbolinks:load", (e)  => {
+  //URLがcards/newの時だけ記述内容を実行
+  if(document.URL.match(/\/cards\/new/)) {
 
   // Payjpnの初期化
   Payjp.setPublicKey('pk_test_5368ce76b1e8ded509d2a439');
@@ -35,4 +37,5 @@ document.addEventListener(
       }
     });
   });
+ }
 }, false);

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -95,12 +95,13 @@ class CardsController < ApplicationController
     @parents = Category.where(ancestry: nil)
   end
 
+  # referrerを用いて直前のURLによって、ページ遷移先を振り分け
   def set_redirect_path
     path = Rails.application.routes.recognize_path(request.referrer)
     p_query = URI(request.referer).query
     params_p_query = Rack::Utils.parse_nested_query(p_query)
-    
-    if path[:controller] == "users/cards" && path[:action] == "new" 
+
+    if path[:controller] == "users/cards" && path[:action] == "new"
       redirect_to card_path(current_user.id)
     else
       redirect_to buy_item_path(params_p_query["item_id"])

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -27,7 +27,7 @@ class CardsController < ApplicationController
       )
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save
-        redirect_to root_path
+        set_redirect_path
       else
         redirect_to action: "new"
       end
@@ -93,6 +93,18 @@ class CardsController < ApplicationController
 
   def set_category
     @parents = Category.where(ancestry: nil)
+  end
+
+  def set_redirect_path
+    path = Rails.application.routes.recognize_path(request.referrer)
+    p_query = URI(request.referer).query
+    params_p_query = Rack::Utils.parse_nested_query(p_query)
+    
+    if path[:controller] == "users/cards" && path[:action] == "new" 
+      redirect_to card_path(current_user.id)
+    else
+      redirect_to buy_item_path(params_p_query["item_id"])
+    end
   end
 
 end

--- a/app/controllers/users/cards_controller.rb
+++ b/app/controllers/users/cards_controller.rb
@@ -1,4 +1,3 @@
 class Users::CardsController < CardsController
-  def new
-  end
+  def new; end
 end

--- a/app/controllers/users/cards_controller.rb
+++ b/app/controllers/users/cards_controller.rb
@@ -1,0 +1,4 @@
+class Users::CardsController < CardsController
+  def new
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,9 @@
 class UsersController < ApplicationController
-  def user_my_page;
+  def user_my_page
     @parents = Category.where(ancestry: nil)
    end
 
-  def sign_out; 
+  def sign_out
     @parents = Category.where(ancestry: nil)
   end
 end

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -6,7 +6,7 @@
     - if @card.blank?
       .card-show-inner
         %h3.card-show-list クレジットカード一覧
-        = link_to new_card_path, class: "add-card-btn" do
+        = link_to new_users_card_path, class: "add-card-btn" do
           = icon('fas', 'credit-card',  class: "add-card-btn__icon") 
           %span カードを追加する
 

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -47,7 +47,7 @@
         - else
           .buy-body__item__card
             %h3.payment-info 支払い方法
-            = link_to new_card_path, class: "payment-info--blue" do
+            = link_to buy_cards_new_path(:item_id => @item.id), class: "payment-info--blue" do
               = icon('fas', 'plus',  class: "payment-info--blue") 
               %span 登録してください
 

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -32,7 +32,7 @@
         - if @card
           .buy-body__item--justified
             %h3.payment-info 支払い方法            
-            = link_to '変更する', card_path, class: "payment-info--blue"
+            = link_to '変更する', card_path(current_user.id), class: "payment-info--blue"
           %span.set-payment クレジットカード
           .set-payment
             = "**** **** **** " + "#{@card.last4}"

--- a/app/views/users/cards/new.html.haml
+++ b/app/views/users/cards/new.html.haml
@@ -1,0 +1,57 @@
+= render "shared/header"
+.reg-main.clearfix
+  .reg-wrapper
+    .reg-title
+      %h2 クレジットカード情報入力
+    .reg-content
+      .reg-content__inner
+        = form_tag("/cards", method: :post, id: 'inputForm',  name: "inputForm", class: "reg-card-form") do
+          .reg-content__inner__form
+            %label{:for => "card_number"}カード番号
+            %span.card-field__require 必須
+            = text_field_tag "card_number", "", class: "card-field__input", placeholder: "半角数字のみ"
+            
+            
+          %ul.reg__card--list
+            %li.reg__card--icon
+              = image_tag("visa.svg", id:"icon-visa", class: "icon")
+            %li.reg__card--icon
+              = image_tag("master-card.svg", id:"icon-master",class: "icon")
+            %li.reg__card--icon
+              = image_tag("saison-card.svg", id:"icon--saison",class: "icon")
+            %li.reg__card--icon
+              = image_tag("jcb.svg", id:"icon--jcb",class: "icon")
+            %li.reg__card--icon
+              = image_tag("american_express.svg", id:"icon--americanexpress",class: "icon")
+            %li.reg__card--icon
+              = image_tag("dinersclub.svg", id:"icon--diners",class: "icon")
+            %li.reg__card--icon
+              = image_tag("discover.svg", id:"icon--discover",class: "icon")
+
+          .card-field
+            %label 有効期限
+            %span.card-field__require 必須
+            %br/
+            
+            .card-field__select-wrapper
+              = select_tag "exp_month", options_for_select(["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]), class: "card-field__input--half"
+              %span.card-field__select 月
+            .card-field__select-wrapper
+              = select_tag "exp_year", options_for_select((2020..2030)), class: "card-field__input--half"
+              %span.card-field__select 年
+
+            .card-field__add--question
+              = link_to '#' do 
+                %span.card-field__add--question__icon ?
+                カード裏面の番号とは？
+              %end
+              
+
+          %label{:for => "cxc"}セキュリティコード
+          %span.card-field__require 必須
+          = text_field_tag "cvc", "", class: "card-field__input", placeholder: "カード背面4桁もしくは3桁の番号"
+                      
+          #card_token
+            = submit_tag "追加する", id: "token_submit", class: "reg-card__btn", data: { disable_with: "送信中..." }
+  = render "users/side_bar"
+= render "shared/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,9 @@ Rails.application.routes.draw do
   }
   root 'tests#index'
   resources :tests
-  
+  # 購入ページでのカード登録のためのURLを設定
   get 'buy/cards/new' => 'cards#new'
-  resources :cards, only: %i[create show destroy] 
+  resources :cards, only: %i[create show destroy]
 
   resources :items, only: %i[new create show edit update destroy] do
     member do
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   end
 
   resources :categories, only: %i[index]
-
+  # ユーザーマイページでのカード登録のためのURLを設定
   namespace :users do
     resources :cards, only: :new
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
   }
   root 'tests#index'
   resources :tests
-  resources :cards, only: %i[new create show destroy]
+  
+  get 'buy/cards/new' => 'cards#new'
+  resources :cards, only: %i[create show destroy] 
+
   resources :items, only: %i[new create show edit update destroy] do
     member do
       get 'buy', to: 'items#buy'
@@ -20,6 +23,10 @@ Rails.application.routes.draw do
   end
 
   resources :categories, only: %i[index]
+
+  namespace :users do
+    resources :cards, only: :new
+  end
 
   resources :users do
     collection do


### PR DESCRIPTION
# What
①Payjp.jsがURL（cards/new）を含むページでのみ読み込む様に記述変更
②カード登録したら直前のページに遷移する様に実装。遷移前のURLによって、リダイレクトするページが変わる様に条件分岐を実装

- ルーティングの再構築（遷移前のURLを区別するため）
- users/newにcardsディレクトリと同様のhtmlファイルを作成
- cardsコントローラーに、ルーティング振り分けのためのメソッド（set_redirect_path）を実装
※実装に当たり、refererを使用
参考サイト　https://qiita.com/kagashow0116/items/3ea7af5d292bcdd43990

# Why

UX向上のため


・ユーザーマイページからカードを追加したらカード詳細ページへ遷移

[![Screenshot from Gyazo](https://gyazo.com/b910a6188cae0b7c138662dfad92b33c/raw)](https://gyazo.com/b910a6188cae0b7c138662dfad92b33c)

・購入確認ページからカードを追加したら購入ページへ遷移

[![Screenshot from Gyazo](https://gyazo.com/e00ea36cd4d8c90b81c6a1420cebaa69/raw)](https://gyazo.com/e00ea36cd4d8c90b81c6a1420cebaa69)

